### PR TITLE
[ HOTFIX ] Add configurable forcePathStyle option

### DIFF
--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -169,6 +169,10 @@ function S3GetClient() {
         opts = { ...opts, endpoint: process.env.S3_ENDPOINT }
     }
 
+    if (process.env.S3_FORCEPATHSTYLE) {
+        opts = { ...opts, forcePathStyle: process.env.S3_FORCEPATHSTYLE === "true" }
+    }
+
     const client = new S3Client(opts)
 
     return client;


### PR DESCRIPTION
To make Frank work with OpenStack swift object storage, the option to set `forcePathStyle : true` is needed.
This PR makes it possible to set this value via env `S3_FORCEPATHSTYLE`

(hope things are good with you and the family btw, @jnordstrom1983 👶 🚲)